### PR TITLE
 Brash Assault's HP thresholds are incorrect

### DIFF
--- a/public/data/passives/b/brash-assault-2.json
+++ b/public/data/passives/b/brash-assault-2.json
@@ -6,7 +6,7 @@
     "icon": "/images/icons/passives/brash-assault-2.png",
     "attack_follow_up": {
         "trigger": "damaged",
-        "threshold": 0.3,
+        "threshold": 0.4,
         "counterable":true
     },
     "link": "https://kagerochart.com/hero/passives/brash-assault-2",

--- a/public/data/passives/b/brash-assault-3.json
+++ b/public/data/passives/b/brash-assault-3.json
@@ -7,7 +7,7 @@
     "link": "https://kagerochart.com/hero/passives/brash-assault-3",
     "attack_follow_up": {
         "trigger": "damaged",
-        "threshold": 0.3,
+        "threshold": 0.5,
         "counterable":true
     },
     "id": "brash-assault-3"


### PR DESCRIPTION
Brash Assault 2 and 3 currently both activate at 30% (Passive B only, the Sacred Seal ones work fine). This edit brings them back to their true thresholds.